### PR TITLE
fix: log cloudwatch overflow as metadata only

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,14 @@ class Plugin {
         if (sizeInKB(JSON.stringify(events)) < OBJECT_SIZE_LIMIT) {
           await pluginObj.cwEvents.putEvents(events).promise();
         } else {
-          console.log('unable to log to cloudwatch (size constraint)', events);
+          const estimatedSizeKB = sizeInKB(JSON.stringify(events));
+          const requestId = body && body.requestId ? body.requestId : undefined;
+          console.log('unable to log to cloudwatch (size constraint)', {
+            DetailType: this.event,
+            Source: pluginObj.Source || 'ti2',
+            estimatedSizeKB,
+            requestId,
+          });
         }
       });
     });


### PR DESCRIPTION
## Summary
- when an event exceeds cloudwatch size constraints, log only compact metadata
- include detail type, source, estimated size, and requestId
- avoid dumping full oversized event payloads to stdout

## Why
- prevents oversized payloads from causing additional memory/log amplification